### PR TITLE
Update coco AMDSEV to setup SNP on RHEL host

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,8 @@ if [[ "$BUILD_PACKAGE" = "1" ]]; then
 		cp linux/linux-*-guest-*.deb $OUTPUT_DIR/linux/guest -v
 		cp linux/linux-*-host-*.deb $OUTPUT_DIR/linux/host -v
 	else
-		cp linux/kernel-*.rpm $OUTPUT_DIR/linux -v
+		cp linux/kernel-*host*.rpm $OUTPUT_DIR/linux/host -v
+		cp linux/kernel-*guest*.rpm $OUTPUT_DIR/linux/guest -v
 	fi
 
 	cp launch-qemu.sh ${OUTPUT_DIR} -v

--- a/common.sh
+++ b/common.sh
@@ -155,7 +155,10 @@ build_install_ovmf()
 		GCCVERS="GCC5"
 	fi
 
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	# A race condition exists in edk2 build - set threads to 1 for now
+	# Previous value: -n $(getconf _NPROCESSORS_ONLN)
+	# Only seen the error on Bergamo systems
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
 
 	# initialize git repo, or update existing remote to currently configured one
 	if [ -d ovmf ]; then

--- a/common.sh
+++ b/common.sh
@@ -63,7 +63,7 @@ build_kernel()
 
 		pushd ${V} >/dev/null
 			run_cmd git fetch --depth 1 current "${BRANCH}"
-			run_cmd git checkout "current/${BRANCH}"
+			run_cmd git checkout "${BRANCH}"
 			COMMIT=$(git log --format="%h" -1 HEAD)
 
 			run_cmd "cp /boot/config-$(uname -r) .config"
@@ -173,7 +173,7 @@ build_install_ovmf()
 
 	pushd ovmf >/dev/null
 		run_cmd git fetch current
-		run_cmd git checkout current/${OVMF_BRANCH}
+		run_cmd git checkout ${OVMF_BRANCH}
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig
@@ -212,7 +212,7 @@ build_install_qemu()
 
 	pushd qemu >/dev/null
 		run_cmd git fetch current
-		run_cmd git checkout current/${QEMU_BRANCH}
+		run_cmd git checkout ${QEMU_BRANCH}
 		run_cmd ./configure --target-list=x86_64-softmmu --prefix=$DEST
 		run_cmd $MAKE
 		run_cmd $MAKE install

--- a/common.sh
+++ b/common.sh
@@ -158,7 +158,7 @@ build_install_ovmf()
 	# A race condition exists in edk2 build - set threads to 1 for now
 	# Previous value: -n $(getconf _NPROCESSORS_ONLN)
 	# Only seen the error on Bergamo systems
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/AmdSev/AmdSevX64.dsc"
 
 	# initialize git repo, or update existing remote to currently configured one
 	if [ -d ovmf ]; then
@@ -182,11 +182,11 @@ build_install_ovmf()
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig
+		touch OvmfPkg/AmdSev/Grub/grub.efi
 		run_cmd $BUILD_CMD
 
 		mkdir -p $DEST
-		run_cmd cp -f Build/OvmfX64/DEBUG_$GCCVERS/FV/OVMF_CODE.fd $DEST
-		run_cmd cp -f Build/OvmfX64/DEBUG_$GCCVERS/FV/OVMF_VARS.fd $DEST
+		run_cmd cp -f Build/AmdSev/DEBUG_$GCCVERS/FV/OVMF.fd $DEST
 
 		COMMIT=$(git log --format="%h" -1 HEAD)
 		run_cmd echo $COMMIT >../source-commit.ovmf

--- a/common.sh
+++ b/common.sh
@@ -18,18 +18,6 @@ build_kernel()
 	mkdir -p linux
 	pushd linux >/dev/null
 
-	if [ ! -d guest ]; then
-		run_cmd git clone ${KERNEL_GIT_URL} guest
-		pushd guest >/dev/null
-		run_cmd git remote add current ${KERNEL_GIT_URL}
-		popd
-	fi
-
-	if [ ! -d host ]; then
-		# use a copy of guest repo as the host repo
-		run_cmd cp -r guest host
-	fi
-
 	for V in guest host; do
 		# Check if only a "guest" or "host" or kernel build is requested
 		if [ "$kernel_type" != "" ]; then
@@ -40,8 +28,15 @@ build_kernel()
 
 		if [ "${V}" = "guest" ]; then
 			BRANCH="${KERNEL_GUEST_BRANCH}"
+			KERNEL_GIT_URL="${KERNEL_GUEST_GIT_URL:-${KERNEL_GIT_URL}}"
 		else
 			BRANCH="${KERNEL_HOST_BRANCH}"
+			KERNEL_GIT_URL="${KERNEL_HOST_GIT_URL:-${KERNEL_GIT_URL}}"
+		fi
+
+		if [ ! -d "${V}" ]; then
+			run_cmd git clone -b "${BRANCH}" --depth 1 "${KERNEL_GIT_URL}" "${V}"
+			run_cmd git -C "${V}" remote add current "${KERNEL_GIT_URL}"
 		fi
 
 		# If ${KERNEL_GIT_URL} is ever changed, 'current' remote will be out
@@ -67,8 +62,8 @@ build_kernel()
 		run_cmd $MAKE distclean
 
 		pushd ${V} >/dev/null
-			run_cmd git fetch current
-			run_cmd git checkout current/${BRANCH}
+			run_cmd git fetch --depth 1 current "${BRANCH}"
+			run_cmd git checkout "current/${BRANCH}"
 			COMMIT=$(git log --format="%h" -1 HEAD)
 
 			run_cmd "cp /boot/config-$(uname -r) .config"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
 	apt-get -y install qemu ovmf
 else
-	dnf install @virt edk2-ovmf -y
+	dnf install -y qemu-kvm edk2-ovmf
 fi
 
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then

--- a/stable-commits
+++ b/stable-commits
@@ -3,13 +3,13 @@
 #
 
 # hypervisor commit
-KERNEL_GIT_URL="https://github.com/AMDESE/linux.git"
-KERNEL_HOST_BRANCH="snp-host-latest"
-KERNEL_GUEST_BRANCH="snp-guest-latest"
+KERNEL_GIT_URL="https://github.com/confidential-containers/linux.git"
+KERNEL_HOST_BRANCH="amd-snp-host-202402240000"
+KERNEL_GUEST_BRANCH="amd-snp-guest-202402240000"
 
 # qemu commit
-QEMU_GIT_URL="https://github.com/AMDESE/qemu.git"
-QEMU_BRANCH="snp-latest"
+QEMU_GIT_URL="https://github.com/confidential-containers/qemu.git"
+QEMU_BRANCH="amd-snp-202402240000"
 
 # guest bios
 #   An AP creation fix added after the 'edk2-stable202302' tag/release is
@@ -19,5 +19,5 @@ QEMU_BRANCH="snp-latest"
 #   please use the 'sev-snp-legacy' branch of this AMDSEV repo instead,
 #   which will build the latest known-working QEMU/OVMF trees for older
 #   SNP hypervisor/host kernels.
-OVMF_GIT_URL="https://github.com/AMDESE/ovmf.git"
-OVMF_BRANCH="snp-latest"
+OVMF_GIT_URL="https://github.com/confidential-containers/edk2.git"
+OVMF_BRANCH="amd-snp-202402240000"


### PR DESCRIPTION
Added RHEL related commits to setup SNP on RHEL host using coco branch of sev-utils/snp.sh (branch link: [here)](https://github.com/amd/sev-utils/blob/coco/tools/snp.sh)