### PR TITLE
Added ovmf fix  for Zeex repo clone issue

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -175,6 +175,11 @@ build_install_ovmf()
 	pushd ovmf >/dev/null
 		run_cmd git fetch current
 		run_cmd git checkout ${OVMF_BRANCH}
+
+		# TODO: Remove this line after bumping to a newer release of OVMF.
+		# Reference: https://github.com/tianocore/edk2/pull/6402
+		sed -i -e "s|https://github.com/Zeex/subhook.git|https://github.com/tianocore/edk2-subhook.git|g" .gitmodules
+
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig


### PR DESCRIPTION
Added ovmf fix for Zeex repo clone issue from Fabiano kata-container commit(aff3d98) during ovmf build

commit reference for the ovmf fix is derived from this [link](https://github.com/kata-containers/kata-containers/commit/aff3d98ddd1578f8bbd01ecfa6c8665ebc9122fe) 