### PR TITLE
versions: update kernel to 6.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Y
 
 Note: SNP requires OVMF be used as the guest BIOS in order to boot. This implies that the guest must have been initially installed using OVMF so that a UEFI partition is present.
 
-If you do not already have an installed guest, you can use the launch-qemu.sh script to create it:
+If you do not already have an installed guest, you can use the launch-qemu.sh script to create it (be sure to append "console=ttyS0,115200n8" to the installation kernel command line in order to perform the installation via the serial console):
 
 ````
 # ./launch-qemu.sh -hda <your_qcow2_file> -cdrom <your_distro_installation_iso_file>

--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,8 @@ if [[ "$BUILD_PACKAGE" = "1" ]]; then
 		cp linux/linux-*-guest-*.deb $OUTPUT_DIR/linux/guest -v
 		cp linux/linux-*-host-*.deb $OUTPUT_DIR/linux/host -v
 	else
-		cp linux/kernel-*.rpm $OUTPUT_DIR/linux -v
+		cp linux/kernel-*host*.rpm $OUTPUT_DIR/linux/host -v
+		cp linux/kernel-*guest*.rpm $OUTPUT_DIR/linux/guest -v
 	fi
 
 	cp launch-qemu.sh ${OUTPUT_DIR} -v

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,10 @@ if [ -z "$1" ]; then
 	build_install_qemu "$INSTALL_DIR"
 	build_install_ovmf "$INSTALL_DIR/share/qemu"
 	build_kernel $2
+	if [ $? -ne 0 ]; then
+		echo "build failed: $?"
+		exit 1
+	fi
 else
 	case "$1" in
 	qemu)

--- a/common.sh
+++ b/common.sh
@@ -159,7 +159,7 @@ build_install_ovmf()
 	# A race condition exists in edk2 build - set threads to 1 for now
 	# Previous value: -n $(getconf _NPROCESSORS_ONLN)
 	# Only seen the error on Bergamo systems
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/AmdSev/AmdSevX64.dsc"
 
 	# initialize git repo, or update existing remote to currently configured one
 	if [ -d ovmf ]; then
@@ -183,12 +183,11 @@ build_install_ovmf()
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig
+		touch OvmfPkg/AmdSev/Grub/grub.efi
 		run_cmd $BUILD_CMD
 
 		mkdir -p $DEST
-		run_cmd cp -f Build/OvmfX64/DEBUG_$GCCVERS/FV/OVMF_CODE.fd $DEST
-		run_cmd cp -f Build/OvmfX64/DEBUG_$GCCVERS/FV/OVMF_VARS.fd $DEST
-		run_cmd cp -f Build/OvmfX64/DEBUG_$GCCVERS/FV/OVMF.fd $DEST
+		run_cmd cp -f Build/AmdSev/DEBUG_$GCCVERS/FV/OVMF.fd $DEST
 
 		COMMIT=$(git log --format="%h" -1 HEAD)
 		run_cmd echo $COMMIT >../source-commit.ovmf

--- a/common.sh
+++ b/common.sh
@@ -18,18 +18,6 @@ build_kernel()
 	mkdir -p linux
 	pushd linux >/dev/null
 
-	if [ ! -d guest ]; then
-		run_cmd git clone ${KERNEL_GIT_URL} guest
-		pushd guest >/dev/null
-		run_cmd git remote add current ${KERNEL_GIT_URL}
-		popd
-	fi
-
-	if [ ! -d host ]; then
-		# use a copy of guest repo as the host repo
-		run_cmd cp -r guest host
-	fi
-
 	for V in guest host; do
 		# Check if only a "guest" or "host" or kernel build is requested
 		if [ "$kernel_type" != "" ]; then
@@ -40,8 +28,15 @@ build_kernel()
 
 		if [ "${V}" = "guest" ]; then
 			BRANCH="${KERNEL_GUEST_BRANCH}"
+			KERNEL_GIT_URL="${KERNEL_GUEST_GIT_URL:-${KERNEL_GIT_URL}}"
 		else
 			BRANCH="${KERNEL_HOST_BRANCH}"
+			KERNEL_GIT_URL="${KERNEL_HOST_GIT_URL:-${KERNEL_GIT_URL}}"
+		fi
+
+		if [ ! -d "${V}" ]; then
+			run_cmd git clone -b "${BRANCH}" --depth 1 "${KERNEL_GIT_URL}" "${V}"
+			run_cmd git -C "${V}" remote add current "${KERNEL_GIT_URL}"
 		fi
 
 		# If ${KERNEL_GIT_URL} is ever changed, 'current' remote will be out
@@ -67,8 +62,8 @@ build_kernel()
 		run_cmd $MAKE distclean
 
 		pushd ${V} >/dev/null
-			run_cmd git fetch current
-			run_cmd git checkout current/${BRANCH}
+			run_cmd git fetch --depth 1 current "${BRANCH}"
+			run_cmd git checkout "current/${BRANCH}"
 			COMMIT=$(git log --format="%h" -1 HEAD)
 
 			run_cmd "cp /boot/config-$(uname -r) .config"

--- a/common.sh
+++ b/common.sh
@@ -63,7 +63,7 @@ build_kernel()
 
 		pushd ${V} >/dev/null
 			run_cmd git fetch --depth 1 current "${BRANCH}"
-			run_cmd git checkout "current/${BRANCH}"
+			run_cmd git checkout "${BRANCH}"
 			COMMIT=$(git log --format="%h" -1 HEAD)
 
 			run_cmd "cp /boot/config-$(uname -r) .config"
@@ -174,7 +174,7 @@ build_install_ovmf()
 
 	pushd ovmf >/dev/null
 		run_cmd git fetch current
-		run_cmd git checkout current/${OVMF_BRANCH}
+		run_cmd git checkout ${OVMF_BRANCH}
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig
@@ -213,7 +213,7 @@ build_install_qemu()
 
 	pushd qemu >/dev/null
 		run_cmd git fetch current
-		run_cmd git checkout current/${QEMU_BRANCH}
+		run_cmd git checkout ${QEMU_BRANCH}
 		run_cmd ./configure --target-list=x86_64-softmmu --prefix=$DEST
 		run_cmd $MAKE
 		run_cmd $MAKE install

--- a/common.sh
+++ b/common.sh
@@ -175,6 +175,11 @@ build_install_ovmf()
 	pushd ovmf >/dev/null
 		run_cmd git fetch current
 		run_cmd git checkout ${OVMF_BRANCH}
+
+		# TODO: Remove this line after bumping to a newer release of OVMF.
+		# Reference: https://github.com/tianocore/edk2/pull/6402
+		sed -i -e "s|https://github.com/Zeex/subhook.git|https://github.com/tianocore/edk2-subhook.git|g" .gitmodules
+
 		run_cmd git submodule update --init --recursive
 		run_cmd make -C BaseTools
 		. ./edksetup.sh --reconfig

--- a/common.sh
+++ b/common.sh
@@ -156,7 +156,10 @@ build_install_ovmf()
 		GCCVERS="GCC5"
 	fi
 
-	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n $(getconf _NPROCESSORS_ONLN) ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
+	# A race condition exists in edk2 build - set threads to 1 for now
+	# Previous value: -n $(getconf _NPROCESSORS_ONLN)
+	# Only seen the error on Bergamo systems
+	BUILD_CMD="nice build -q --cmd-len=64436 -DDEBUG_ON_SERIAL_PORT=TRUE -n 1 ${GCCVERS:+-t $GCCVERS} -a X64 -p OvmfPkg/OvmfPkgX64.dsc"
 
 	# initialize git repo, or update existing remote to currently configured one
 	if [ -d ovmf ]; then

--- a/common.sh
+++ b/common.sh
@@ -206,7 +206,8 @@ build_install_ovmf()
 		sed -i -e "s|https://github.com/Zeex/subhook.git|https://github.com/tianocore/edk2-subhook.git|g" .gitmodules
 
 		run_cmd git submodule update --init --recursive
-		run_cmd make -C BaseTools
+		run_cmd make -C BaseTools clean
+		run_cmd make -C BaseTools -j $(getconf _NPROCESSORS_ONLN)
 		. ./edksetup.sh --reconfig
 		touch OvmfPkg/AmdSev/Grub/grub.efi
 		run_cmd $BUILD_CMD

--- a/common.sh
+++ b/common.sh
@@ -84,7 +84,12 @@ build_kernel()
 
 		MAKE="make -C ${V} -j $(getconf _NPROCESSORS_ONLN) LOCALVERSION="
 
-		run_cmd $MAKE distclean
+		# dirty directories might cause checkout to fail, but first time checkout
+		# won't have a Makefile in the first place to allow for failures in that
+		# case
+		if [ -f ${V}/Makefile ]; then
+			run_cmd $MAKE distclean
+		fi
 
 		pushd ${V} >/dev/null
 			run_cmd git fetch --depth 1 current "${BRANCH}"

--- a/common.sh
+++ b/common.sh
@@ -14,9 +14,34 @@ build_kernel()
 {
 	set -x
 	kernel_type=$1
+	kernel_config_path="/boot/config-$(uname -r)"
 	shift
 	mkdir -p linux
 	pushd linux >/dev/null
+
+	if [ ! -d guest ]; then
+		run_cmd git clone ${KERNEL_GIT_URL} guest
+		pushd guest >/dev/null
+		run_cmd git remote add current ${KERNEL_GIT_URL}
+		popd
+	fi
+
+	if [ ! -d host ]; then
+		# use a copy of guest repo as the host repo
+		run_cmd cp -r guest host
+	fi
+
+	if [ "$kernel_type" == "host" ]; then
+		if [ -n "$KERNEL_HOST_CONFIG_TEMPLATE" ]; then
+			kernel_config_path=${KERNEL_HOST_CONFIG_TEMPLATE}
+		fi
+	else
+		if [ -n "$KERNEL_GUEST_CONFIG_TEMPLATE" ]; then
+			kernel_config_path=${KERNEL_GUEST_CONFIG_TEMPLATE}
+		fi
+	fi
+
+	run_cmd echo "Using $kernel_config_path as template kernel configuration."
 
 	for V in guest host; do
 		# Check if only a "guest" or "host" or kernel build is requested
@@ -66,7 +91,7 @@ build_kernel()
 			run_cmd git checkout "${BRANCH}"
 			COMMIT=$(git log --format="%h" -1 HEAD)
 
-			run_cmd "cp /boot/config-$(uname -r) .config"
+			run_cmd "cp $kernel_config_path .config"
 			run_cmd ./scripts/config --set-str LOCALVERSION "$VER-$COMMIT"
 			run_cmd ./scripts/config --disable LOCALVERSION_AUTO
 			run_cmd ./scripts/config --enable  EXPERT

--- a/common.sh
+++ b/common.sh
@@ -31,18 +31,6 @@ build_kernel()
 		run_cmd cp -r guest host
 	fi
 
-	if [ "$kernel_type" == "host" ]; then
-		if [ -n "$KERNEL_HOST_CONFIG_TEMPLATE" ]; then
-			kernel_config_path=${KERNEL_HOST_CONFIG_TEMPLATE}
-		fi
-	else
-		if [ -n "$KERNEL_GUEST_CONFIG_TEMPLATE" ]; then
-			kernel_config_path=${KERNEL_GUEST_CONFIG_TEMPLATE}
-		fi
-	fi
-
-	run_cmd echo "Using $kernel_config_path as template kernel configuration."
-
 	for V in guest host; do
 		# Check if only a "guest" or "host" or kernel build is requested
 		if [ "$kernel_type" != "" ]; then
@@ -53,16 +41,18 @@ build_kernel()
 
 		if [ "${V}" = "guest" ]; then
 			BRANCH="${KERNEL_GUEST_BRANCH}"
-			KERNEL_GIT_URL="${KERNEL_GUEST_GIT_URL:-${KERNEL_GIT_URL}}"
+			kernel_config_path=${KERNEL_GUEST_CONFIG_TEMPLATE}
+			if [ -n "$KERNEL_GUEST_CONFIG_TEMPLATE" ]; then
+				kernel_config_path=${KERNEL_GUEST_CONFIG_TEMPLATE}
+			fi
 		else
 			BRANCH="${KERNEL_HOST_BRANCH}"
-			KERNEL_GIT_URL="${KERNEL_HOST_GIT_URL:-${KERNEL_GIT_URL}}"
+			if [ -n "$KERNEL_HOST_CONFIG_TEMPLATE" ]; then
+				kernel_config_path=${KERNEL_HOST_CONFIG_TEMPLATE}
+			fi
 		fi
 
-		if [ ! -d "${V}" ]; then
-			run_cmd git clone -b "${BRANCH}" --depth 1 "${KERNEL_GIT_URL}" "${V}"
-			run_cmd git -C "${V}" remote add current "${KERNEL_GIT_URL}"
-		fi
+		run_cmd echo "Using $kernel_config_path as template kernel configuration for $V."
 
 		# If ${KERNEL_GIT_URL} is ever changed, 'current' remote will be out
 		# of date, so always update the remote URL first. Also handle case

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
 	apt-get -y install qemu ovmf
 else
-	dnf install @virt edk2-ovmf -y
+	dnf install -y qemu-kvm edk2-ovmf
 fi
 
 if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then

--- a/launch-qemu.sh
+++ b/launch-qemu.sh
@@ -45,7 +45,6 @@ usage() {
 	echo "                    (Requires that QEMU is built on a host that supports libslirp-dev 4.7 or newer)"
 	echo " -monitor PATH      Path to QEMU monitor socket (default: $MONITOR_PATH)"
 	echo " -log PATH          Path to QEMU console log (default: $QEMU_CONSOLE_LOG)"
-	echo " -certs PATH        Path to SNP certificate blob for guest (default: none)"
 	exit 1
 }
 
@@ -141,9 +140,6 @@ while [ -n "$1" ]; do
 				shift
 				;;
 		-log)           QEMU_CONSOLE_LOG="$2"
-				shift
-				;;
-		-certs) CERTS_PATH="$2"
 				shift
 				;;
 		*) 		usage
@@ -290,11 +286,7 @@ if [ -n "${SEV}" ]; then
 
 		add_opts "-object memory-backend-memfd,id=ram1,size=${MEM}M,share=true,prealloc=false"
 		add_opts "-machine memory-backend=ram1"
-		if [ "${CERTS_PATH}" != "" ]; then
-			add_opts "-object sev-snp-guest,id=sev0,policy=${POLICY},cbitpos=${CBITPOS},reduced-phys-bits=1,certs-path=${CERTS_PATH}"
-		else
-			add_opts "-object sev-snp-guest,id=sev0,policy=${POLICY},cbitpos=${CBITPOS},reduced-phys-bits=1"
-		fi
+		add_opts "-object sev-snp-guest,id=sev0,policy=${POLICY},cbitpos=${CBITPOS},reduced-phys-bits=1"
 	else
 		POLICY=$((0x01))
 		[ -n "${SEV_ES}" ] && POLICY=$((POLICY | 0x04))

--- a/launch-qemu.sh
+++ b/launch-qemu.sh
@@ -20,6 +20,7 @@ SEV=
 SEV_ES=
 SEV_SNP=
 ALLOW_DEBUG=
+DRY=
 
 EXEC_PATH="./usr/local"
 UEFI_PATH="$EXEC_PATH/share/qemu"
@@ -45,6 +46,7 @@ usage() {
 	echo "                    (Requires that QEMU is built on a host that supports libslirp-dev 4.7 or newer)"
 	echo " -monitor PATH      Path to QEMU monitor socket (default: $MONITOR_PATH)"
 	echo " -log PATH          Path to QEMU console log (default: $QEMU_CONSOLE_LOG)"
+	echo " -dry               Print generated command-line but don't launch the guest"
 	exit 1
 }
 
@@ -140,6 +142,9 @@ while [ -n "$1" ]; do
 				shift
 				;;
 		-log)           QEMU_CONSOLE_LOG="$2"
+				shift
+				;;
+		-dry)   DRY="1"
 				shift
 				;;
 		*) 		usage
@@ -333,7 +338,9 @@ stty intr ^]
 echo "Launching VM ..."
 echo "  $QEMU_CMDLINE"
 sleep 1
-bash ${QEMU_CMDLINE} 2>&1 | tee -a ${QEMU_CONSOLE_LOG}
+if [ -z $DRY ]; then
+	bash ${QEMU_CMDLINE} 2>&1 | tee -a ${QEMU_CONSOLE_LOG}
+fi
 
 # restore the mapping
 stty intr ^c

--- a/launch-qemu.sh
+++ b/launch-qemu.sh
@@ -225,7 +225,7 @@ rm -rf $QEMU_CMDLINE
 add_opts "$QEMU_EXE"
 
 # Basic virtual machine property
-add_opts "-enable-kvm -cpu ${CPU_MODEL} -machine q35"
+add_opts "-enable-kvm -cpu ${CPU_MODEL},+la57,phys-bits=52 -machine q35"
 
 # add number of VCPUs
 [ -n "${SMP}" ] && add_opts "-smp ${SMP},maxcpus=255"

--- a/launch-qemu.sh
+++ b/launch-qemu.sh
@@ -275,7 +275,7 @@ fi
 
 # If this is SEV guest then add the encryption device objects to enable support
 if [ -n "${SEV}" ]; then
-	add_opts "-machine memory-encryption=sev0,vmport=off" 
+	add_opts "-machine confidential-guest-support=sev0,vmport=off"
 	get_cbitpos
 
 	if [ -n "${SEV_SNP}" ]; then

--- a/stable-commits
+++ b/stable-commits
@@ -3,13 +3,13 @@
 #
 
 # hypervisor commit
-KERNEL_GIT_URL="https://github.com/AMDESE/linux.git"
-KERNEL_HOST_BRANCH="snp-host-latest"
-KERNEL_GUEST_BRANCH="snp-guest-latest"
+KERNEL_GIT_URL="https://github.com/torvalds/linux.git"
+KERNEL_HOST_BRANCH="v6.12"
+KERNEL_GUEST_BRANCH="v6.12"
 
 # qemu commit
-QEMU_GIT_URL="https://github.com/AMDESE/qemu.git"
-QEMU_BRANCH="snp-latest"
+QEMU_GIT_URL="https://github.com/qemu/qemu.git"
+QEMU_BRANCH="v9.2.0"
 
 # guest bios
 #   An AP creation fix added after the 'edk2-stable202302' tag/release is
@@ -19,5 +19,5 @@ QEMU_BRANCH="snp-latest"
 #   please use the 'sev-snp-legacy' branch of this AMDSEV repo instead,
 #   which will build the latest known-working QEMU/OVMF trees for older
 #   SNP hypervisor/host kernels.
-OVMF_GIT_URL="https://github.com/AMDESE/ovmf.git"
-OVMF_BRANCH="snp-latest"
+OVMF_GIT_URL="https://github.com/tianocore/edk2.git"
+OVMF_BRANCH="edk2-stable202411"

--- a/stable-commits
+++ b/stable-commits
@@ -16,12 +16,5 @@ QEMU_GIT_URL="https://github.com/qemu/qemu.git"
 QEMU_BRANCH="v9.2.0"
 
 # guest bios
-#   An AP creation fix added after the 'edk2-stable202302' tag/release is
-#   known to break AP booting on older SNP hypervisor/host kernels based
-#   on the 5.19 kernel tree. If you are building packages to be used in
-#   conjunction with this older 5.19 level of SNP hypervisor support,
-#   please use the 'sev-snp-legacy' branch of this AMDSEV repo instead,
-#   which will build the latest known-working QEMU/OVMF trees for older
-#   SNP hypervisor/host kernels.
 OVMF_GIT_URL="https://github.com/tianocore/edk2.git"
-OVMF_BRANCH="edk2-stable202411"
+OVMF_BRANCH="edk2-stable202502"

--- a/stable-commits
+++ b/stable-commits
@@ -3,9 +3,9 @@
 #
 
 # hypervisor commit
-KERNEL_GIT_URL="https://github.com/torvalds/linux.git"
-KERNEL_HOST_BRANCH="v6.12"
-KERNEL_GUEST_BRANCH="v6.12"
+KERNEL_GIT_URL="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
+KERNEL_HOST_BRANCH="v6.16.1"
+KERNEL_GUEST_BRANCH="v6.16.1"
 
 # base/template kernel config (defaults to /boot/config-`uname -r`)
 #KERNEL_HOST_CONFIG_TEMPLATE=/path/to/kernel/config

--- a/stable-commits
+++ b/stable-commits
@@ -15,6 +15,6 @@ KERNEL_GUEST_BRANCH="v6.12"
 QEMU_GIT_URL="https://github.com/qemu/qemu.git"
 QEMU_BRANCH="v9.2.0"
 
-# guest bios
-OVMF_GIT_URL="https://github.com/tianocore/edk2.git"
-OVMF_BRANCH="edk2-stable202502"
+# guest bios (snp-latest branch currently points to "edk2-stable202502")
+OVMF_GIT_URL="https://github.com/AMDESE/ovmf.git"
+OVMF_BRANCH="snp-latest"

--- a/stable-commits
+++ b/stable-commits
@@ -7,6 +7,10 @@ KERNEL_GIT_URL="https://github.com/torvalds/linux.git"
 KERNEL_HOST_BRANCH="v6.12"
 KERNEL_GUEST_BRANCH="v6.12"
 
+# base/template kernel config (defaults to /boot/config-`uname -r`)
+#KERNEL_HOST_CONFIG_TEMPLATE=/path/to/kernel/config
+#KERNEL_GUEST_CONFIG_TEMPLATE=/path/to/kernel/config
+
 # qemu commit
 QEMU_GIT_URL="https://github.com/qemu/qemu.git"
 QEMU_BRANCH="v9.2.0"


### PR DESCRIPTION
Updating stable-commits to provide a way for
users to install the latest supported kernel
(v6.16.1) to match what is used in Kata and
CoCo.